### PR TITLE
게시판 api 만들기 - Data REST 적용 및 테스트 정의 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation("org.springframework.boot:spring-boot-starter-data-rest")
+	implementation("org.springframework.data:spring-data-rest-hal-explorer")
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/fastcampus/projectboard/domain/ArticleComment.java
+++ b/src/main/java/com/fastcampus/projectboard/domain/ArticleComment.java
@@ -2,23 +2,16 @@ package com.fastcampus.projectboard.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
 import java.util.Objects;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
-import org.springframework.data.annotation.CreatedBy;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedBy;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
 @ToString
@@ -28,7 +21,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 		@Index(columnList = "createdBy"),
 })
 @Entity
-public class ArticleComment {
+public class ArticleComment extends AuditingFields {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/fastcampus/projectboard/repository/ArticleCommentRepository.java
+++ b/src/main/java/com/fastcampus/projectboard/repository/ArticleCommentRepository.java
@@ -2,7 +2,9 @@ package com.fastcampus.projectboard.repository;
 
 import com.fastcampus.projectboard.domain.ArticleComment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleCommentRepository extends JpaRepository<ArticleComment, Long> {
 
 }

--- a/src/main/java/com/fastcampus/projectboard/repository/ArticleCommentRepository.java
+++ b/src/main/java/com/fastcampus/projectboard/repository/ArticleCommentRepository.java
@@ -8,3 +8,4 @@ import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 public interface ArticleCommentRepository extends JpaRepository<ArticleComment, Long> {
 
 }
+

--- a/src/main/java/com/fastcampus/projectboard/repository/ArticleRepository.java
+++ b/src/main/java/com/fastcampus/projectboard/repository/ArticleRepository.java
@@ -2,7 +2,9 @@ package com.fastcampus.projectboard.repository;
 
 import com.fastcampus.projectboard.domain.Article;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleRepository extends JpaRepository<Article, Long> {
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,5 +32,8 @@ spring:
   sql:
     init:
       mode: always
-
+  data:
+    rest:
+      base-path: /api
+      detection-strategy: annotated
 

--- a/src/test/java/com/fastcampus/projectboard/controller/DataRestTest.java
+++ b/src/test/java/com/fastcampus/projectboard/controller/DataRestTest.java
@@ -1,0 +1,79 @@
+package com.fastcampus.projectboard.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@DisplayName("Data REST - API test")
+@Transactional
+@AutoConfigureMockMvc
+@SpringBootTest(webEnvironment = WebEnvironment.MOCK)
+public class DataRestTest {
+
+	private final MockMvc mvc;
+
+	public DataRestTest(@Autowired MockMvc mvc) {
+		this.mvc = mvc;
+	}
+
+	@DisplayName("[api] 게시글 리스트 조회")
+	@Test
+	void givenNothing_whenRequestingArticles_thenReturnsArticlesJsonResponse() throws Exception {
+
+		// When & Then
+		mvc.perform(get("/api/articles"))
+				.andExpect(status().isOk())
+				.andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+	}
+
+	@DisplayName("[api] 게시글 단건 조회")
+	@Test
+	void givenNothing_whenRequestingArticles_thenReturnsArticleJsonResponse() throws Exception {
+
+		// When & Then
+		mvc.perform(get("/api/articles/1"))
+				.andExpect(status().isOk())
+				.andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+	}
+
+	@DisplayName("[api] 게시글 -> 댓글 리스트 조회")
+	@Test
+	void givenNothing_whenRequestingArticleCommentFromArticle_thenReturnsArticleCommentsJsonResponse() throws Exception {
+
+		// When & Then
+		mvc.perform(get("/api/articles/1/articleComments"))
+				.andExpect(status().isOk())
+				.andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+	}
+
+	@DisplayName("[api] 댓글 리스트 조회")
+	@Test
+	void givenNothing_whenRequestingArticleComments_thenReturnsArticleCommentsJsonResponse() throws Exception {
+
+		// When & Then
+		mvc.perform(get("/api/articleComments"))
+				.andExpect(status().isOk())
+				.andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+	}
+
+	@DisplayName("[api] 댓글 단건 조회")
+	@Test
+	void givenNothing_whenRequestingArticleComment_thenReturnsArticleCommentJsonResponse() throws Exception {
+
+		// When & Then
+		mvc.perform(get("/api/articleComments/1"))
+				.andExpect(status().isOk())
+				.andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+	}
+}


### PR DESCRIPTION
게시판, 댓글 데이터는 간편하게 Spring Data REST로 서비스하고, 해당 api 들의 존재 여부만 체크하게끔 통합테스트 작성 